### PR TITLE
Remove nix-repl, zsh references from dwmTools

### DIFF
--- a/dwn-tool.nix
+++ b/dwn-tool.nix
@@ -1,4 +1,4 @@
-{ lib, runCommand, nix, nix-repl, zsh }:
+{ lib, runCommand, nix, }:
 
 runCommand "dwn" {
   scriptFolder = ./scripts;
@@ -13,6 +13,4 @@ runCommand "dwn" {
     substituteAll "$s" "$target"
     chmod +x "$target"
   done
-  ln -s ${zsh}/bin/zsh $scriptBase/dwn-zsh
-  ln -s ${nix-repl}/bin/nix-repl $scriptBase/dwn-nix-repl
 ''


### PR DESCRIPTION
nix-repl no longer exists as of nixpkgs 18.09, being replaced with the `nix repl` subcommand; this leads to webnf/dwn#2.

The zsh reference created an extra dependency with no documentation or tools appearing to rely on it; prune while at it.